### PR TITLE
po - active link colour

### DIFF
--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -198,22 +198,22 @@ input[type=submit] {
 
 #nav .home a:hover,#nav .home a:focus,#nav .home a:active, #nav .home_set a {
   background-image: url(../after/img/homeicon_hover.png);
-  background-color: #005a9c;
+  background-color: #005a9c; color: #fff;
 }
 
 #nav .news a:hover, #nav .news a:focus, #nav .news a:active, #nav .news_set a {
   background-image: url(../after/img/newsicon_hover.png);
-  background-color: #005a9c;
+  background-color: #005a9c; color: #fff;
 }
 
 #nav .facts a:hover, #nav .facts a:focus, #nav .facts a:active, #nav .facts_set a {
   background-image: url(../after/img/factsicon_hover.png);
-  background-color: #005a9c;
+  background-color: #005a9c; color: #fff;
 }
 
 #nav .survey a:hover, #nav .survey a:focus, #nav .survey a:active, #nav .survey_set a {
   background-image: url(../after/img/surveyicon_hover.png);
-  background-color: #005a9c;
+  background-color: #005a9c; color: #fff;
 }
 
 #nav a:focus {

--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -216,7 +216,8 @@ input[type=submit] {
 
 #nav .survey a:hover, #nav .survey a:focus, #nav .survey a:active, #nav .survey_set a {
   background-image: url(../after/img/surveyicon_hover.png);
-  background-color: #005a9c; color: #fff;
+  background-color: #005a9c;
+  color: #fff;
 }
 
 #nav a:focus {

--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -198,7 +198,8 @@ input[type=submit] {
 
 #nav .home a:hover,#nav .home a:focus,#nav .home a:active, #nav .home_set a {
   background-image: url(../after/img/homeicon_hover.png);
-  background-color: #005a9c; color: #fff;
+  background-color: #005a9c;
+  color: #fff;
 }
 
 #nav .news a:hover, #nav .news a:focus, #nav .news a:active, #nav .news_set a {

--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -204,7 +204,8 @@ input[type=submit] {
 
 #nav .news a:hover, #nav .news a:focus, #nav .news a:active, #nav .news_set a {
   background-image: url(../after/img/newsicon_hover.png);
-  background-color: #005a9c; color: #fff;
+  background-color: #005a9c;
+  color: #fff;
 }
 
 #nav .facts a:hover, #nav .facts a:focus, #nav .facts a:active, #nav .facts_set a {

--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -210,7 +210,8 @@ input[type=submit] {
 
 #nav .facts a:hover, #nav .facts a:focus, #nav .facts a:active, #nav .facts_set a {
   background-image: url(../after/img/factsicon_hover.png);
-  background-color: #005a9c; color: #fff;
+  background-color: #005a9c;
+  color: #fff;
 }
 
 #nav .survey a:hover, #nav .survey a:focus, #nav .survey a:active, #nav .survey_set a {


### PR DESCRIPTION
workaround - :active not firing on #nav links resulting in lack of link colour change on active items. 
This works, but class should be .nav_active rather than 4 classes xxx_set for nav links.